### PR TITLE
composer.json should not pointed to dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "vimeo/psalm": "dev-master",
+        "vimeo/psalm": "^4.10",
         "psalm/plugin-symfony": "^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
It is not recommanded to use dev-master for tools following classic semver. It can broke package.