### PR TITLE
README: install as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Team.
 
 To install the plugin:
 
-1. Run `composer require mortenson/psalm-plugin-drupal:dev-master`
+1. Run `composer require mortenson/psalm-plugin-drupal:dev-master --dev`
 2. Change directories to the root of your Drupal installation (ex: `cd web`, `cd docroot`).
 3. Create a `psalm.xml` file in the root of your Drupal installation like:
 ```xml


### PR DESCRIPTION
My understanding is that tools like psalm and phpstan should be added as dev dependencies.